### PR TITLE
Update 04.ForeignInterface.md

### DIFF
--- a/04.ForeignInterface.md
+++ b/04.ForeignInterface.md
@@ -517,7 +517,7 @@ foreign-callable和foreign-procedure 允许任意地嵌套外部和Scheme调用�
 
 ## 4.5 外部数据（Foreign Data）
 
-本节介绍直接创建和操作外部数据的过程，即在存在于Scheme堆外的数据。由于foreign-alloc和foreign-sizeof的异常，就它们不（不能）检查传给它们的地址的有效性而言，这些过程本质上是不安全的。不恰当的使用这些过程会导致无效的内存引用，毁坏数据，或系统崩溃。
+本节介绍的过程直接创建和操作外部数据，即存在于Scheme堆外的数据。由于foreign-alloc和foreign-sizeof的异常，就它们不（不能）检查传给它们的地址的有效性而言，这些过程本质上是不安全的。不恰当的使用这些过程会导致无效的内存引用，毁坏数据，或系统崩溃。
 
 该节也介绍一个更高阶的操作外部数据的语法机制，包含外部结果体，联合体，数组，位域。语法接口比过程接口更加安全，但是仍必须假设对给出的被操作的对象类型的地址是正确的。
 
@@ -585,7 +585,7 @@ uptr等效于void*；两者都被当作unsigned integers，即指针的大小。
 + single-float, and
 + double-float.
 
-（译者注：原文中，这里多出现了一段以下函数的address描述）
+地址必须是一个在-2<sup>w-1</sup>到2<sup>w</sup> - 1范围的exact integer，其中w是指针的字节宽度，即对于64位机器是64。offset必须是一个exact fixnum。address与offset之和能够寻址一个足够容纳type类型的值大小的可读内存块，在一个由foreign-alloc返回的存储块中，且并没有被foreign-free释放，或者在由其他机制获取的一个存储块中，例如，外部调用。对于多字节的值，假设使用机器本身的endianness。
 
 过程: (foreign-set! type address offset value)
 返回: 见下文


### PR DESCRIPTION
1. 调整一个了翻译的语序。
2. 删除译者注的描述。原文中，这一个段是对foreign-ref的参数address的描述。虽然与下面foreign-set!的参数address的描述一致。